### PR TITLE
0.0.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -32,17 +32,18 @@ jobs:
       run: pip list
 
     - name: Run tests and show coverage on the command line
-      run: coverage run --source=emptylog --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
-
-    - name: Upload reports to codecov
-      env:
-        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      if: runner.os == 'Linux'
       run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        find . -iregex "codecov.*"
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN}
+        coverage run --source=emptylog --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
+        coverage xml
+
+    - name: Upload coverage to Coveralls
+      if: runner.os == 'Linux'
+      env:
+        COVERALLS_REPO_TOKEN: ${{secrets.COVERALLS_REPO_TOKEN}}
+      uses: coverallsapp/github-action@v2
+      with:
+        format: cobertura
+        file: coverage.xml
 
     - name: Run tests and show the branch coverage on the command line
       run: coverage run --branch --source=emptylog --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://static.pepy.tech/badge/emptylog/month)](https://pepy.tech/project/emptylog)
 [![Downloads](https://static.pepy.tech/badge/emptylog)](https://pepy.tech/project/emptylog)
-[![codecov](https://codecov.io/gh/pomponchik/emptylog/graph/badge.svg?token=I7Be1jVBeB)](https://codecov.io/gh/pomponchik/emptylog)
+[![Coverage Status](https://coveralls.io/repos/github/pomponchik/emptylog/badge.svg?branch=main)](https://coveralls.io/github/pomponchik/emptylog?branch=main)
 [![Lines of code](https://sloc.xyz/github/pomponchik/emptylog/?category=code)](https://github.com/boyter/scc/)
 [![Hits-of-Code](https://hitsofcode.com/github/pomponchik/emptylog?branch=main)](https://hitsofcode.com/github/pomponchik/emptylog/view?branch=main)
 [![Test-Package](https://github.com/pomponchik/emptylog/actions/workflows/tests_and_coverage.yml/badge.svg)](https://github.com/pomponchik/emptylog/actions/workflows/tests_and_coverage.yml)

--- a/emptylog/loggers_group.py
+++ b/emptylog/loggers_group.py
@@ -15,7 +15,7 @@ else:
     GroupIterator = Iterator[LoggerProtocol]  # pragma: no cover
 
 class LoggersGroup(AbstractLogger):
-    loggers: Tuple[LoggerProtocol, ...]
+    loggers: Tuple[LoggerProtocol, ...]  # pragma: no cover
 
     def __init__(self, *loggers: LoggerProtocol) -> None:
         for logger in loggers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'emptylog'
-version = '0.0.10'
+version = '0.0.11'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = 'Mimicking the logger protocol'
 readme = 'README.md'
 requires-python = '>=3.8'
 dependencies = [
-    'printo>=0.0.5',
+    'printo>=0.0.8',
 ]
 classifiers = [
   'Operating System :: MacOS :: MacOS X',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'License :: OSI Approved :: MIT License',
   'Topic :: Software Development :: Libraries',
   'Topic :: Software Development :: Testing',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==7.4.3
+pytest==8.0.2
 coverage==7.6.1
 build==1.2.2.post1
 twine==6.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,5 +5,5 @@ twine==6.1.0
 mypy==1.14.1
 ruff==0.14.6
 mutmut==3.2.3
-full_match==0.0.1
+full_match==0.0.3
 loguru==0.7.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ coverage==7.6.1
 build==1.2.2.post1
 twine==6.1.0
 mypy==1.14.1
-ruff==0.9.9
+ruff==0.14.6
 mutmut==3.2.3
 full_match==0.0.1
 loguru==0.7.3

--- a/tests/test_abstract_logger.py
+++ b/tests/test_abstract_logger.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-import full_match
+from full_match import match
 from loguru import logger as loguru_logger
 
 from emptylog.abstract_logger import AbstractLogger
@@ -98,7 +98,7 @@ def test_all_loggers_are_instances_of_abstract_logger(logger):
     ),
 )
 def test_sum_with_wrong_first_operand(logger, wrong_operand):
-    with pytest.raises(NotImplementedError, match=full_match('The addition operation is defined only for loggers.')):
+    with pytest.raises(NotImplementedError, match=match('The addition operation is defined only for loggers.')):
         wrong_operand + logger
 
 
@@ -120,7 +120,7 @@ def test_sum_with_wrong_first_operand(logger, wrong_operand):
     ),
 )
 def test_sum_with_wrong_second_operand(logger, wrong_operand):
-    with pytest.raises(NotImplementedError, match=full_match('The addition operation is defined only for loggers.')):
+    with pytest.raises(NotImplementedError, match=match('The addition operation is defined only for loggers.')):
         logger + wrong_operand
 
 

--- a/tests/test_loggers_group.py
+++ b/tests/test_loggers_group.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-import full_match
+from full_match import match
 from loguru import logger as loguru_logger
 
 from emptylog import LoggersGroup, MemoryLogger
@@ -29,7 +29,7 @@ def test_len_of_group():
     ),
 )
 def test_create_group_with_not_loggers(wrong_logger, exception_message):
-    with pytest.raises(TypeError, match=full_match(exception_message)):
+    with pytest.raises(TypeError, match=match(exception_message)):
         LoggersGroup(wrong_logger)
 
 


### PR DESCRIPTION
A purely technical update, with no new functionality.

- Added full support for `Python 3.14`.
- `Python 3.14` and `3.14 free threading` runners added to CI. Also updated versions of some of the Github Actions used.
- The provider of the test coverage display changed to `Coveralls`.
- Updated some dependencies.